### PR TITLE
feat：登録されているアイテム一覧ページを取得するページを作成

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env

--- a/src/app/items/ItemList.tsx
+++ b/src/app/items/ItemList.tsx
@@ -1,0 +1,83 @@
+import { Items as Item } from "@/types/items";
+import {
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+  Container,
+  Chip,
+  Box,
+} from "@mui/material";
+
+type Props = {
+  items: Item[];
+};
+
+const ItemList = ({ items }: Props) => {
+  if (!items || items.length === 0) {
+    return (
+      <Container maxWidth="md">
+        <Typography variant="h4" gutterBottom>
+          アイテム一覧
+        </Typography>
+        <Typography variant="body1">アイテムがありません</Typography>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="md">
+      <Typography variant="h4" gutterBottom>
+        アイテム一覧
+      </Typography>
+      <List>
+        {items.map((item) => (
+          <ListItem key={item.id} divider>
+            <ListItemText
+              primary={
+                <Box
+                  component="div"
+                  display="flex"
+                  justifyContent="space-between"
+                >
+                  <Typography component="span" variant="h6">
+                    {item.name}
+                  </Typography>
+                  <Typography component="span" variant="body2">
+                    在庫: {item.quantity}
+                  </Typography>
+                </Box>
+              }
+              secondary={
+                <Box component="div">
+                  <Typography
+                    component="span"
+                    variant="body2"
+                    display="block"
+                    gutterBottom
+                  >
+                    {item.description}
+                  </Typography>
+                  <Box component="div" display="flex" gap={1} flexWrap="wrap">
+                    {item.itemsCategories?.map((cat) => (
+                      <Chip
+                        key={cat.id}
+                        label={cat.name}
+                        size="small"
+                        color="primary"
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              }
+              primaryTypographyProps={{ component: "div" }}
+              secondaryTypographyProps={{ component: "div" }}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+};
+
+export default ItemList;

--- a/src/app/items/page.tsx
+++ b/src/app/items/page.tsx
@@ -1,0 +1,37 @@
+// app/items/page.tsx
+import { ItemResponse } from "@/types/items";
+import ItemList from "./ItemList";
+import React from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+const fetchItems = async () => {
+  const res = await fetch(`${API_URL}/items?pages=1&sort_order=1`, {
+    next: { revalidate: 0 },
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    console.error("API Response:", {
+      status: res.status,
+      statusText: res.statusText,
+      headers: Object.fromEntries(res.headers.entries()),
+      body: errorText,
+    });
+    throw new Error(`Failed to fetch items: ${res.status} ${res.statusText}`);
+  }
+
+  const data: ItemResponse = await res.json();
+  return data.results;
+};
+
+const ItemsPage = async () => {
+  try {
+    const items = await fetchItems();
+    return <ItemList items={items} />;
+  } catch (error) {
+    console.error("Error in ItemsPage:", error);
+    return <div>データの取得に失敗しました</div>;
+  }
+};
+export default ItemsPage;

--- a/src/test/app/items/page.test.tsx
+++ b/src/test/app/items/page.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+// import対象を調整（default exportは関数としてimport）
+import ItemsPage from "@/app/items/page";
+
+// fetchをモック
+global.fetch = vi.fn();
+
+describe("ItemsPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("正常にアイテム一覧を表示する", async () => {
+    const mockData = {
+      results: [
+        {
+          id: "1",
+          name: "アイテムA",
+          quantity: 10,
+          description: "説明A",
+          itemsCategories: [{ id: "1", name: "カテゴリ1" }],
+        },
+      ],
+    };
+
+    // fetchモックの定義
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const Component = await ItemsPage(); // async component を呼び出す
+    render(Component);
+
+    expect(await screen.findByText("アイテムA")).toBeInTheDocument();
+    expect(screen.getByText("在庫: 10")).toBeInTheDocument();
+    expect(screen.getByText("カテゴリ1")).toBeInTheDocument();
+  });
+
+  it("API失敗時にエラーメッセージを表示する", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "サーバーエラー",
+      headers: new Headers(),
+    });
+
+    const Component = await ItemsPage();
+    render(Component);
+
+    expect(await screen.findByText("データの取得に失敗しました")).toBeInTheDocument();
+  });
+});

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "lib": [
       "dom",
       "dom.iterable",
@@ -12,7 +12,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
@@ -24,14 +24,14 @@
     ],
     "paths": {
       "@/*": [
-        "/*"
+        "./*"
       ]
     }
   },
   "include": [
     "next-env.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx",
+    "**/*.ts",
+    "**/*.tsx",
     ".next/types/**/*.ts"
   ],
   "exclude": [

--- a/src/types/items.ts
+++ b/src/types/items.ts
@@ -1,0 +1,21 @@
+export type ItemCategory = {
+  id: number;
+  name: string;
+  itemId: number;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type Items = {
+  id: number;
+  name: string;
+  quantity: number;
+  description: string;
+  itemsCategories?: ItemCategory[];
+}
+
+export type ItemResponse = {
+  count: number;
+  results: Items[];
+}

--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -8,5 +9,10 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: "./test/setup",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
   },
 });


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#8 
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- ルーティングを追加
- fetchを使ってデータを取得(SSRで実施)
- 取得したデータをリスト表示

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 単体テストを実施

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- バックエンドサーバーを起動
- フロントエンドサーバーを起動
- `/items`のpathを実施

# 補足・確認事項
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

# 実行結果
![スクリーンショット 2025-05-04 16 56 42](https://github.com/user-attachments/assets/ef8ab8e0-b09f-4137-b3fd-619122d6ecec)
